### PR TITLE
Use Wrapped: False

### DIFF
--- a/src/redeem.rs
+++ b/src/redeem.rs
@@ -61,7 +61,7 @@ pub async fn redeem_payment(
             from: subscription.subscriber.parse::<Address>()?,
             to: subscription.recipient.parse::<Address>()?,
             target_flow: amount * periods,
-            use_wrapped_balances: Some(true),
+            use_wrapped_balances: Some(false),
             from_tokens: None,
             to_tokens: None,
             exclude_from_tokens: None,


### PR DESCRIPTION
Similar to the TS package https://github.com/deluXtreme/redeem-ts/pull/11 and mentioned by the circles team https://github.com/aboutcircles/circles-nethermind-plugin/issues/124#issuecomment-3302485300

use wrapped was causing failing transactions.

**Before:**

```
2025-09-18T08:48:37.143033Z  INFO redeem_rs: Found 1 subscriptions
2025-09-18T08:48:37.176531Z  INFO redeem_rs::redeem: Redeeming RedeemableSubscription {
    id: "0x9bafd7444ba424830038c3357cd0df67361781a317e5d12315e6a07d9ebd03d2",
    recipient: "0x6b69683c8897e3d18e74b1ba117b49f80423da5d",
    subscriber: "0xcf6dc192dc292d5f2789da2db02d6dd4f41f4214",
    amount: "10000000000000000",
    periods: 1,
    category: Trusted,
}
Error: TransportError(ErrorResp(ErrorPayload { code: 3, message: "execution reverted", data: Some(RawValue("0xacfdb444")) }))
```

**After:**

```
2025-09-18T09:04:39.667617Z  INFO redeem_rs: Found 1 subscriptions
2025-09-18T09:04:39.669209Z  INFO redeem_rs::redeem: Redeeming RedeemableSubscription {
    id: "0x9bafd7444ba424830038c3357cd0df67361781a317e5d12315e6a07d9ebd03d2",
    recipient: "0x6b69683c8897e3d18e74b1ba117b49f80423da5d",
    subscriber: "0xcf6dc192dc292d5f2789da2db02d6dd4f41f4214",
    amount: "10000000000000000",
    periods: 1,
    category: Trusted,
}
2025-09-18T09:04:41.117719Z  INFO redeem_rs::redeem: Redeemed 0x9bafd7444ba424830038c3357cd0df67361781a317e5d12315e6a07d9ebd03d2 at: https://gnosisscan.io/tx/0x57c2753051bf594dfa77da1309af71fcbf3ed0f8e3ba80297fa3aa654fefcdc5
```

Its still totally unclear why this is happening... but it appears to work fine now.